### PR TITLE
Fixed regex bug with multiple subnets

### DIFF
--- a/eks-cluster/eks-workers-stack.sh
+++ b/eks-cluster/eks-workers-stack.sh
@@ -28,7 +28,7 @@ VPC_ID=`aws eks --region $AWS_REGION describe-cluster --name $EKS_CLUSTER | grep
 echo "Using VpcId: $VPC_ID"
 
 # Customize Subnet ID
-SUBNETS=`aws eks --region $AWS_REGION  describe-cluster --name $EKS_CLUSTER | grep subnet- | sed 's/\"//g'| sed ':a;N;$!ba;s/\n//g' | sed 's/ //g' | sed 's/,/\\\\,/g'`
+SUBNETS=`aws eks --region $AWS_REGION  describe-cluster --name $EKS_CLUSTER | grep subnet- | sed 's/\"//g'| sed ':a;N;$!ba;s/\n//g' | sed 's/ //g' | head -1 | sed 's/,//g'`
 echo "Using Subnets: $SUBNETS"
 
 
@@ -37,7 +37,6 @@ CONTROL_SG=`aws eks --region $AWS_REGION  describe-cluster --name $EKS_CLUSTER |
 echo "Using Cluster control security group: $CONTROL_SG"
 
 VOLUME_SIZE=200
-
 
 aws cloudformation create-stack --region $AWS_REGION  --stack-name $STACK_NAME \
 --template-url $CFN_URL \


### PR DESCRIPTION
Fixed bug where multiple subnets returned as multiple lines, breaking the cloudformation command. Also only spawn worker nodes in one subnet.